### PR TITLE
Use the version specified in Cargo.toml in the code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use std::fs::{read_link, File};
 use std::io::{self, BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-const VERSION: &'static str = "PhoneWords v. 0.0.7-4";
+const VERSION: &'static str = concat!("PhoneWords v. ", env!("CARGO_PKG_VERSION"));
 const HELP: &'static str = "Usage:
         phonewords -h | -v
         phonewords <number> [-q]


### PR DESCRIPTION
I had another idea while I looked at your "version bump" commit. Maybe you like this change also ;)

If the environment variable CARGO_PKG_VERSION is not set during
compilation the compiler will raise an error. Cargo sets this variable,
if you invoke rustc manually make sure to set it!
